### PR TITLE
Generate cmake package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ compile_commands.json
 CTestTestfile.cmake
 *.swp
 .vs/*
+.vscode/
+CMakeSettings.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build/
+out/
 CMakeCache.txt
 CMakeFiles
 CMakeScripts

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,8 @@ add_library(hotplate_static STATIC
 	src/hotplate_static/hotplate.cpp
 	src/hotplate_static/include/hotplate/hotplate.h)
 target_include_directories(hotplate_static
-	PUBLIC src/hotplate_static/include)
+	PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/src/hotplate_static/include>
+	       $<INSTALL_INTERFACE:include>)
 target_compile_features(hotplate_static
 	PUBLIC cxx_strong_enums
 	       cxx_noexcept)
@@ -99,6 +100,7 @@ write_basic_package_version_file(
 # Installation steps
 include(GNUInstallDirs)
 install(TARGETS hotplate_static hotplate_app
+	EXPORT hotplate_targets
 	RUNTIME DESTINATION bin
 	LIBRARY DESTINATION lib
 	ARCHIVE DESTINATION lib)
@@ -109,3 +111,15 @@ install(FILES
 	${CMAKE_CURRENT_BINARY_DIR}/hotplateConfig.cmake
 	${CMAKE_CURRENT_BINARY_DIR}/hotplateConfigVersion.cmake
 	DESTINATION "lib/cmake/hotplate")
+
+# Install a path-agnostic hotplateTargets.cmake file.
+install(EXPORT hotplate_targets
+	DESTINATION lib/cmake/hotplate
+	NAMESPACE hotplate::
+	FILE hotplateTargets.cmake)
+
+# Generate a local hotplateTargets.cmake file with paths to the current build.
+export(
+	EXPORT hotplate_targets
+	NAMESPACE hotplate::
+	FILE hotplateTargets.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.5)
 
 # Read version from cache
-set(hotplate_VERSION 0.0.0 CACHE STRING "Hotplate version (ex: 1.2.3)")
+set(hotplate_VERSION 0.1.1 CACHE STRING "Hotplate version (ex: 1.2.3)")
 
 project(hotplate VERSION ${hotplate_VERSION})
 enable_testing()
@@ -81,12 +81,31 @@ add_test(
 	NAME hotplate_boost_test
 	COMMAND "${CURRENT_BUILD_DIR}/hotplate_boost_test")
 
+# CMake package configuration files
+include(CMakePackageConfigHelpers)
+set(hotplate_INSTALLDIR_INCLUDE include/)
+set(hotplate_INSTALLDIR_LIB lib/)
+configure_package_config_file(
+	hotplateConfig.cmake.in
+	${CMAKE_CURRENT_BINARY_DIR}/hotplateConfig.cmake
+	PATH_VARS hotplate_INSTALLDIR_INCLUDE
+	          hotplate_INSTALLDIR_LIB
+	INSTALL_DESTINATION lib/hotplate/cmake)
+write_basic_package_version_file(
+	${CMAKE_CURRENT_BINARY_DIR}/hotplateConfigVersion.cmake
+	VERSION ${hotplate_VERSION}
+	COMPATIBILITY SameMajorVersion)
+
 # Installation steps
 include(GNUInstallDirs)
 install(TARGETS hotplate_static hotplate_app
 	RUNTIME DESTINATION bin
 	LIBRARY DESTINATION lib
 	ARCHIVE DESTINATION lib)
-install(DIRECTORY src/hotplate_static/include
-	DESTINATION .
+install(DIRECTORY src/hotplate_static/include/hotplate
+	DESTINATION include
 	FILES_MATCHING PATTERN "*.h")
+install(FILES
+	${CMAKE_CURRENT_BINARY_DIR}/hotplateConfig.cmake
+	${CMAKE_CURRENT_BINARY_DIR}/hotplateConfigVersion.cmake
+	DESTINATION "lib/cmake/hotplate")

--- a/hotplateConfig.cmake.in
+++ b/hotplateConfig.cmake.in
@@ -1,0 +1,9 @@
+# See https://cmake.org/cmake/help/latest/module/CMakePackageConfigHelpers.html#module:CMakePackageConfigHelpers
+set(hotplate_VERSION "@hotplate_VERSION@")
+
+@PACKAGE_INIT@
+
+set_and_check(hotplate_INCLUDE_DIR "@PACKAGE_hotplate_INSTALLDIR_INCLUDE@")
+set_and_check(hotplate_LIBRARY_DIR "@PACKAGE_hotplate_INSTALLDIR_LIB@")
+
+check_required_components(hotplate)

--- a/hotplateConfig.cmake.in
+++ b/hotplateConfig.cmake.in
@@ -3,9 +3,9 @@ set(hotplate_VERSION "@hotplate_VERSION@")
 
 @PACKAGE_INIT@
 
-set_and_check(hotplate_INCLUDE_DIR "@PACKAGE_hotplate_INSTALLDIR_INCLUDE@")
-set_and_check(hotplate_LIBRARY_DIR "@PACKAGE_hotplate_INSTALLDIR_LIB@")
+#set_and_check(hotplate_INCLUDE_DIR "@PACKAGE_hotplate_INSTALLDIR_INCLUDE@")
+#set_and_check(hotplate_LIBRARY_DIR "@PACKAGE_hotplate_INSTALLDIR_LIB@")
 
-include(hotplateTargets)
+include("${CMAKE_CURRENT_LIST_DIR}/hotplateTargets.cmake")
 
 check_required_components(hotplate)

--- a/hotplateConfig.cmake.in
+++ b/hotplateConfig.cmake.in
@@ -6,4 +6,6 @@ set(hotplate_VERSION "@hotplate_VERSION@")
 set_and_check(hotplate_INCLUDE_DIR "@PACKAGE_hotplate_INSTALLDIR_INCLUDE@")
 set_and_check(hotplate_LIBRARY_DIR "@PACKAGE_hotplate_INSTALLDIR_LIB@")
 
+include(hotplateTargets)
+
 check_required_components(hotplate)


### PR DESCRIPTION
The CMake "install" target now installs additional files so downstream projects can load a pre-built installation of hotplate:

- <install-dir>/lib/cmake/hotplate/hotplateConfig.cmake
- <install-dir>/lib/cmake/hotplate/hotplateConfigVersion.cmake
- <install-dir>/lib/cmake/hotplate/hotplateTargets.cmake
- <install-dir>/lib/cmake/hotplate/hotplateTargets-debug.cmake

I've tested that a consumer project can successfully load the targets with find_package(hotplate) if the consumer is configured with CMAKE_PREFIX_PATH containing <install-dir>/lib/cmake/hotplate. Other methods have not been tested.